### PR TITLE
Fix unused buffer in floatWorker

### DIFF
--- a/source_modules/file_source/src/main.cpp
+++ b/source_modules/file_source/src/main.cpp
@@ -347,8 +347,6 @@ private:
         FileSourceModule* _this = (FileSourceModule*)ctx;
         double sampleRate = std::max(_this->reader->getSampleRate(), (uint32_t)1);
         int blockSize = std::min((int)(sampleRate / 200.0f), (int)STREAM_BUFFER_SIZE);
-        dsp::complex_t* inBuf = new dsp::complex_t[blockSize];
-
         long long samplesRead = 0;
         sigpath::iqFrontEnd.setCurrentStreamTime(_this->streamStartTime);
 
@@ -362,8 +360,6 @@ private:
                 sigpath::iqFrontEnd.setCurrentStreamTime(currentTime);
             }
         }
-
-        delete[] inBuf;
     }
 
     double getFrequency(std::string filename) {


### PR DESCRIPTION
## Summary
- remove unused buffer allocation in `FileSourceModule::floatWorker`

## Testing
- `g++ -std=c++17 -c source_modules/file_source/src/main.cpp -Icore/src -Isource_modules/file_source/src -Icore/src/dsp -Icore/src/utils -Icore/src/signal_path -Icore/src/gui -Idecoder_modules/radio/src` *(fails: imgui.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6868012e344883278f5e3566ba7757cc